### PR TITLE
Build error fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn read_file_to_u32(filename: &str) -> Option<u32> {
         })
         .ok()
         .and_then(|s| {
-            s.trim_right()
+            s.trim_end()
                 .parse::<u32>()
                 .map_err(|e| format!("Cannot parse {} as integer: {} from `{}`", s, e, filename))
                 .ok()

--- a/src/switch_monitor.rs
+++ b/src/switch_monitor.rs
@@ -98,7 +98,7 @@ impl SwitchMonitor {
         assert_eq!(SIZE, mem::size_of::<Event>());
         let event = unsafe {
             let mut event: Event = mem::zeroed();
-            let mut u: &mut [u8; SIZE] = mem::transmute(&mut event);
+            let u: &mut [u8; SIZE] = mem::transmute(&mut event);
             if let Err(e) = fd.read_exact(u) {
                 error!("Cannot read from event device: {}", e);
                 return (self.state, false);


### PR DESCRIPTION
Ran `cargo fix` to change some deprecated syntax that was giving me build errors.