### PR TITLE
Change legacy /var/run/ to /run/

### DIFF
--- a/illuminanced.service
+++ b/illuminanced.service
@@ -6,7 +6,7 @@ Documentation=https://github.com/mikhail-m1/illuminanced
 [Service]
 Type=forking
 ExecStart=/usr/local/sbin/illuminanced
-PIDFile=/var/run/illuminanced.pid
+PIDFile=/run/illuminanced.pid
 Restart=on-failure
 
 [Install]

--- a/illuminanced.toml
+++ b/illuminanced.toml
@@ -1,7 +1,7 @@
 [daemonize]
 # log_to = "syslog" or /file/path
 log_to = "syslog"
-pid_file = "/var/run/illuminanced.pid"
+pid_file = "/run/illuminanced.pid"
 # log_level = "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"
 log_level = "ERROR"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ impl Config {
 
     pub fn pid_filename(&self) -> &str {
         self.get_str("daemonize", "pid_file")
-            .unwrap_or("/var/run/illuminanced.pid")
+            .unwrap_or("/run/illuminanced.pid")
     }
 
     pub fn light_steps(&self) -> u32 {


### PR DESCRIPTION
I believe /run/ is now the most common directory for PID files. It's also recommended by systemd (man page systemd.service(5) ):
```
PIDFile=
    Takes a path referring to the PID file of the service. Usage of this option is recommended for services where Type= is set to forking. The path specified typically points to a file below /run/.
```
This change also stops a warning when starting the service.