### PR TITLE
separate --no-fork from -d/--debug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -219,7 +219,8 @@ fn run() -> Result<(), ErrorCode> {
     opts.optopt("p", "pid", "set pid file", "filename");
     opts.optopt("c", "config", "config file", "filename");
     opts.optflag("v", "version", "print version");
-    opts.optflag("d", "no-fork", "no fork for debug");
+    opts.optflag("d", "debug", "no fork and debug logging");
+    opts.optflag("", "no-fork", "no fork for debug");
     opts.optflag("h", "help", "print this help");
 
     let matches = match opts.parse(&args[1..]) {
@@ -324,7 +325,7 @@ fn run() -> Result<(), ErrorCode> {
         config.switch_key_code(),
     );
 
-    if !matches.opt_present("no-fork") {
+    if !matches.opt_present("no-fork") && !matches.opt_present("debug") {
         Daemonize::new()
             .pid_file(config.pid_filename())
             .start()


### PR DESCRIPTION
This allows to use the --no-fork flag for service managers like runit that expect programs to stay in the foreground to avoid using pid files. The systemd service could also be changed to use Type=simple with that flag, which is generally prefered over Type=forking, because of the inherent issues of pid files.