### PR TITLE
Config: don't use more light steps than exist

### DIFF
--- a/illuminanced.toml
+++ b/illuminanced.toml
@@ -46,5 +46,5 @@ illuminance_4 = 1100
 light_4 = 5
 
 illuminance_5 = 7100
-light_5 = 10
+light_5 = 9
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,11 +99,13 @@ impl Config {
         let count = self
             .get_u32("light", "points_count")
             .ok_or(ErrorCode::InvalidPointsInConfig)?;
+        let max_light = self.light_steps() - 1;
         let points: Vec<_> = (0..count)
             .map(|i| {
                 self.get_u32("light", &format!("illuminance_{}", i))
                     .and_then(|ill| {
                         self.get_u32("light", &format!("light_{}", i))
+                            .filter(|light| *light <= max_light)
                             .map(|light| LightPoint {
                                 illuminance: ill,
                                 light,


### PR DESCRIPTION
Attempting to use more steps than actually exist (by setting a *`light_N`* value equal or greater than `light_steps`) writes too high a brightness to the sysfs backlight node, generating an "invalid argument" error.

Currently, this uses `.filter()` to map invalid light values to `None`, which will generate an `InvalidPointsInConfig` error later. This seems pretty consistent with existing behavior, erroring when invalid values are provided.

The other option is to just clamp any excessively high values to the largest allowed (*`light_steps` - 1*), and continuing without error. This was my first thought, but it feels misleading to the user to just silently allow this.

This PR also updates the example config file to obey the light-step limit.

Fixes #30